### PR TITLE
Cleanly exit logstash if ZeroMQ raises exception

### DIFF
--- a/lib/logstash/outputs/zeromq.rb
+++ b/lib/logstash/outputs/zeromq.rb
@@ -97,7 +97,11 @@ class LogStash::Outputs::ZeroMQ < LogStash::Outputs::Base
 
   public
   def close
-    error_check(@zsocket.close, "while closing the socket")
+    begin
+      error_check(@zsocket.close, "while closing the socket")
+    rescue RuntimeError => e
+      @logger.error("Failed to properly teardown ZeroMQ")
+    end
   end # def close
 
   private


### PR DESCRIPTION
There are irregularly situations where ZeroMQ raises an exception on
close. There is no need to stop logstash with RuntimeError and
stack backtrace if logstash is already tearing down.

The problem seems to be logstash closing an already closed ZeroMQ
socket.
