### PR TITLE
Added eagain_not_error and noblock config options

### DIFF
--- a/lib/logstash/outputs/zeromq.rb
+++ b/lib/logstash/outputs/zeromq.rb
@@ -59,6 +59,13 @@ class LogStash::Outputs::ZeroMQ < LogStash::Outputs::Base
   #     }
   config :sockopt, :validate => :hash
 
+  # Defines if zeromq return code EAGAIN is an error
+  # This may be used e.g. if ZMQ::SNDTIMEO is set or in combination with `noblock`
+  config :eagain_not_error, :validate => :boolean, :default => false
+
+  # Defines if the zeromq send operation is blocking or not, if setting is true, events are sent in non-blocking mode.
+  config :noblock, :validate => :boolean, :default => false
+
   public
   def register
     require "ffi-rzmq"
@@ -120,7 +127,12 @@ class LogStash::Outputs::ZeroMQ < LogStash::Outputs::Base
       #error_check(@zsocket.send_string(event.sprintf(@topic), ZMQ::SNDMORE),
                   #"in topic send_string")
     end
-    error_check(@zsocket.send_string(payload), "in send_string")
+
+    zmq_send_args = 0
+    if @noblock
+      zmq_send_args = ZMQ::DONTWAIT
+    end
+    error_check(@zsocket.send_string(payload, zmq_send_args), "in send_string", @eagain_not_error)
   rescue => e
     @logger.warn("0mq output exception", :address => @address, :exception => e)
   end

--- a/lib/logstash/util/zeromq.rb
+++ b/lib/logstash/util/zeromq.rb
@@ -21,8 +21,8 @@ module LogStash::Util::ZeroMQ
     @logger.info("0mq: #{server? ? 'connected' : 'bound'}", :address => address)
   end
 
-  def error_check(rc, doing)
-    unless ZMQ::Util.resultcode_ok?(rc)
+  def error_check(rc, doing, eagain_not_error = false)
+    unless ZMQ::Util.resultcode_ok?(rc) || (ZMQ::Util.errno == ZMQ::EAGAIN && eagain_not_error)
       @logger.error("ZeroMQ error while #{doing}", { :error_code => rc })
       raise "ZeroMQ Error while #{doing}"
     end


### PR DESCRIPTION
When using ZMQ::SNDTIMEO with ZeroMQ logstash output
this will produce error messages with return code ZMQ::EAGAIN.
The eagain_not_error configuration parameter allows to ignore these
error messages.
Without ZMQ::SNDTIMEO ZeroMQ logstash output will not respond to
Ctrl+C interrupt if in send_string and there is no connection
to the peer (PUSHPULL).

If noblock is set to true, send_string will use ZMQ::DONTWAIT.
This allows to send without blocking in PUSHPULL.
